### PR TITLE
Do not handle datetime object yourself when you don’t have to

### DIFF
--- a/src/OTP/otp.py
+++ b/src/OTP/otp.py
@@ -1,5 +1,5 @@
 import pyotp
-import datetime
+
 
 class OTP:
     """Library for generating OTP's from a secret
@@ -15,7 +15,8 @@ class OTP:
         | base32secret |
         | base32secret | timestamp |
         """
-        if not timestamp:
-            timestamp = datetime.datetime.utcnow()
         totp = pyotp.TOTP(secret)
-        return totp.at(timestamp)
+        if timestamp:
+            return totp.at(timestamp)
+        else:
+            return totp.now()


### PR DESCRIPTION
This code makes less assumptions in what format pyotp accepts the timestamp in. This make the code work even on older Python versions (3.6 in my test case).